### PR TITLE
ci: reset github pages branch

### DIFF
--- a/.github/workflows/deploy-to-ghpages.yml
+++ b/.github/workflows/deploy-to-ghpages.yml
@@ -42,4 +42,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
-          publish_branch: main


### PR DESCRIPTION
Last deploy failed with:

> Setup auth token
>  [INFO] setup GITHUB_TOKEN
>  Error: Action failed with "You deploy from main to main
>  This operation is prohibited to protect your contents

https://github.com/Hupla-Travel/Hupla-Travel.github.io/actions/runs/10450556511/job/28935179726